### PR TITLE
Materialize task stats into the control plane DB

### DIFF
--- a/ops-catalog/.gitignore
+++ b/ops-catalog/.gitignore
@@ -1,0 +1,10 @@
+dist/
+flow_generated/
+node_modules/
+# We don't really _need_ to ignore these, but it makes it easier to update them when Flow changes
+# how they're generated.
+.eslintrc.js
+.prettierrc.js
+tsconfig.json
+# I think we want to ignore this so that we re-resolve dependencies whenever we deploy this.
+package-lock.json

--- a/ops-catalog/README.md
+++ b/ops-catalog/README.md
@@ -1,0 +1,15 @@
+# Control plane ops catalog
+
+This is the Flow catalog that manages the Flow tasks that we use to materialize stats to the control
+plane database, so that they are made available via REST endpoints.
+
+Whenever a new tenant signs up, they need to be added to `derivations.flow.yaml`,
+`derivations.flow.ts`, and `mock-tasks.flow.yaml`. The intent is to automate that as part of new
+tenant sign up, but it's not done yet.
+
+`local.flow.yaml` exists to allow testing things locally.
+
+The tables that are materialized into are created as part of the sql migration `10_stats.sql`. They
+are not created automatically by the materialization connector so that the migration can define row
+level security policies without requiring that the materialization has already been applied.
+

--- a/ops-catalog/derivations.flow.ts
+++ b/ops-catalog/derivations.flow.ts
@@ -1,0 +1,94 @@
+import { collections, interfaces, registers } from 'flow/modules';
+
+// Implementation for derivation flow.yaml#/collections/estuary~1ops~1task-stats~1by-day/derivation.
+export class EstuaryOpsTaskStatsByDay implements interfaces.EstuaryOpsTaskStatsByDay {
+    hourToDayPublish(
+        source: collections.EstuaryOpsTaskStatsByHour,
+        _register: registers.EstuaryOpsTaskStatsByDay,
+        _previous: registers.EstuaryOpsTaskStatsByDay,
+    ): collections.EstuaryOpsTaskStatsByDay[] {
+        const ts = new Date(source.ts);
+        ts.setUTCHours(0, 0, 0, 0);
+        source.ts = ts.toISOString();
+        return [source];
+    }
+}
+
+// Implementation for derivation flow.yaml#/collections/estuary~1ops~1task-stats~1by-hour/derivation.
+export class EstuaryOpsTaskStatsByHour implements interfaces.EstuaryOpsTaskStatsByHour {
+    minuteToHourPublish(
+        source: collections.EstuaryOpsTaskStatsByMinute,
+        _register: registers.EstuaryOpsTaskStatsByHour,
+        _previous: registers.EstuaryOpsTaskStatsByHour,
+    ): collections.EstuaryOpsTaskStatsByHour[] {
+        const ts = new Date(source.ts);
+        ts.setUTCMilliseconds(0);
+        ts.setUTCSeconds(0);
+        ts.setUTCMinutes(0);
+        source.ts = ts.toISOString();
+        return [source];
+    }
+}
+
+interface HasTimestamp {
+    ts: string;
+}
+
+function truncateToMinute(doc: HasTimestamp) {
+    const date = new Date(doc.ts);
+    date.setUTCMilliseconds(0);
+    date.setUTCSeconds(0);
+    doc.ts = date.toISOString();
+}
+
+// Implementation for derivation flow.yaml#/collections/estuary~1ops~1task-stats~1by-minute/derivation.
+export class EstuaryOpsTaskStatsByMinute implements interfaces.EstuaryOpsTaskStatsByMinute {
+    acmeCoPublish(
+        source: collections.OpsAcmeCoStats,
+        _register: registers.EstuaryOpsTaskStatsByMinute,
+        _previous: registers.EstuaryOpsTaskStatsByMinute,
+    ): collections.EstuaryOpsTaskStatsByMinute[] {
+        truncateToMinute(source);
+        return [source];
+    }
+    deepsyncPublish(
+        source: collections.OpsDeepsyncStats,
+        _register: registers.EstuaryOpsTaskStatsByMinute,
+        _previous: registers.EstuaryOpsTaskStatsByMinute,
+    ): collections.EstuaryOpsTaskStatsByMinute[] {
+        truncateToMinute(source);
+        return [source];
+    }
+    fenestraPublish(
+        source: collections.OpsFenestraStats,
+        _register: registers.EstuaryOpsTaskStatsByMinute,
+        _previous: registers.EstuaryOpsTaskStatsByMinute,
+    ): collections.EstuaryOpsTaskStatsByMinute[] {
+        truncateToMinute(source);
+        return [source];
+    }
+    philPublish(
+        source: collections.OpsPhilStats,
+        _register: registers.EstuaryOpsTaskStatsByMinute,
+        _previous: registers.EstuaryOpsTaskStatsByMinute,
+    ): collections.EstuaryOpsTaskStatsByMinute[] {
+        truncateToMinute(source);
+        return [source];
+    }
+    rocksetPublish(
+        source: collections.OpsRocksetStats,
+        _register: registers.EstuaryOpsTaskStatsByMinute,
+        _previous: registers.EstuaryOpsTaskStatsByMinute,
+    ): collections.EstuaryOpsTaskStatsByMinute[] {
+        truncateToMinute(source);
+        return [source];
+    }
+    wgdPublish(
+        source: collections.OpsWgdStats,
+        _register: registers.EstuaryOpsTaskStatsByMinute,
+        _previous: registers.EstuaryOpsTaskStatsByMinute,
+    ): collections.EstuaryOpsTaskStatsByMinute[] {
+        truncateToMinute(source);
+        return [source];
+    }
+}

--- a/ops-catalog/derivations.flow.yaml
+++ b/ops-catalog/derivations.flow.yaml
@@ -1,0 +1,141 @@
+collections:
+  estuary/ops/task-stats/by-minute:
+    schema: ops-stats-schema.json
+    key: [/shard/name, /shard/keyBegin, /shard/rClockBegin, /ts]
+    projections:
+      kind:
+        location: /shard/kind
+        partition: true
+      name:
+        location: /shard/name
+        partition: true
+      key_begin: /shard/keyBegin
+      rclock_begin: /shard/rClockBegin
+    derivation:
+      transform:
+        acmeCo:
+          source:
+            name: ops/acmeCo/stats
+          publish: { lambda: typescript }
+        deepsync:
+          source:
+            name: ops/deepsync/stats
+          publish: { lambda: typescript }
+        fenestra:
+          source:
+            name: ops/fenestra/stats
+          publish: { lambda: typescript }
+        phil:
+          source:
+            name: ops/phil/stats
+          publish: { lambda: typescript }
+        rockset:
+          source:
+            name: ops/rockset/stats
+          publish: { lambda: typescript }
+        wgd:
+          source:
+            name: ops/wgd/stats
+          publish: { lambda: typescript }
+
+  estuary/ops/task-stats/by-hour:
+    schema: ops-stats-schema.json
+    key: [/shard/name, /shard/keyBegin, /shard/rClockBegin, /ts]
+    projections:
+      kind:
+        location: /shard/kind
+        partition: true
+      name:
+        location: /shard/name
+        partition: true
+      key_begin: /shard/keyBegin
+      rclock_begin: /shard/rClockBegin
+    derivation:
+      transform:
+        minuteToHour:
+          source:
+            name: estuary/ops/task-stats/by-minute
+          publish: { lambda: typescript }
+
+  estuary/ops/task-stats/by-day:
+    schema: ops-stats-schema.json
+    key: [/shard/name, /shard/keyBegin, /shard/rClockBegin, /ts]
+    projections:
+      kind:
+        location: /shard/kind
+        partition: true
+      name:
+        location: /shard/name
+        partition: true
+      key_begin: /shard/keyBegin
+      rclock_begin: /shard/rClockBegin
+    derivation:
+      transform:
+        hourToDay:
+          source:
+            name: estuary/ops/task-stats/by-hour
+          publish: { lambda: typescript }
+
+
+tests:
+  timestamps_are_rounded:
+    - ingest:
+        collection: ops/acmeCo/stats
+        documents:
+          - shard:
+              kind: capture
+              name: acmeCo/test/cap
+              keyBegin: '00000000'
+              rClockBegin: '00000000'
+            ts: '2022-04-03T01:02:03.45678Z'
+            capture:
+              'acmeCo/test/collection':
+                right: {docsTotal: 3, bytesTotal: 99}
+                out: {docsTotal: 3, bytesTotal: 99}
+            txnCount: 2
+            openSecondsTotal: 0.012
+    - verify:
+        collection: estuary/ops/task-stats/by-minute
+        documents:
+          - shard:
+              kind: capture
+              name: acmeCo/test/cap
+              keyBegin: '00000000'
+              rClockBegin: '00000000'
+            ts: '2022-04-03T01:02:00.000Z'
+            capture:
+              'acmeCo/test/collection':
+                right: {docsTotal: 3, bytesTotal: 99}
+                out: {docsTotal: 3, bytesTotal: 99}
+            txnCount: 2
+            openSecondsTotal: 0.012
+    - verify:
+        collection: estuary/ops/task-stats/by-hour
+        documents:
+          - shard:
+              kind: capture
+              name: acmeCo/test/cap
+              keyBegin: '00000000'
+              rClockBegin: '00000000'
+            ts: '2022-04-03T01:00:00.000Z'
+            capture:
+              'acmeCo/test/collection':
+                right: {docsTotal: 3, bytesTotal: 99}
+                out: {docsTotal: 3, bytesTotal: 99}
+            txnCount: 2
+            openSecondsTotal: 0.012
+    - verify:
+        collection: estuary/ops/task-stats/by-day
+        documents:
+          - shard:
+              kind: capture
+              name: acmeCo/test/cap
+              keyBegin: '00000000'
+              rClockBegin: '00000000'
+            ts: '2022-04-03T00:00:00.000Z'
+            capture:
+              'acmeCo/test/collection':
+                right: {docsTotal: 3, bytesTotal: 99}
+                out: {docsTotal: 3, bytesTotal: 99}
+            txnCount: 2
+            openSecondsTotal: 0.012

--- a/ops-catalog/greeting-schema.yaml
+++ b/ops-catalog/greeting-schema.yaml
@@ -1,0 +1,9 @@
+properties:
+  count:
+    type: integer
+  message:
+    type: string
+required:
+- count
+- message
+type: object

--- a/ops-catalog/local.flow.yaml
+++ b/ops-catalog/local.flow.yaml
@@ -1,0 +1,58 @@
+import:
+  - derivations.flow.yaml
+  - mock-tasks.flow.yaml
+
+materializations:
+  estuary/ops/task-stats/to-postgres:
+    shards:
+      logLevel: debug
+    endpoint:
+      flowSink:
+        image: ghcr.io/estuary/materialize-postgres:dev
+        config:
+          database: postgres
+          host: localhost
+          password: postgres
+          port: 5432
+          user: postgres
+
+    bindings:
+      - source: estuary/ops/task-stats/by-minute
+        resource:
+          table: task_stats_by_minute
+        fields:
+          recommended: false
+          include:
+            kind: {}
+            name: {}
+            key_begin: {}
+            rclock_begin: {}
+            ts: {}
+            flow_document: {}
+      - source: estuary/ops/task-stats/by-hour
+        resource:
+          table: task_stats_by_hour
+        fields:
+          recommended: false
+          include:
+            kind: {}
+            name: {}
+            key_begin: {}
+            rclock_begin: {}
+            ts: {}
+            flow_document: {}
+      - source: estuary/ops/task-stats/by-day
+        resource:
+          table: task_stats_by_day
+        fields:
+          recommended: false
+          include:
+            kind: {}
+            name: {}
+            key_begin: {}
+            rclock_begin: {}
+            ts: {}
+            flow_document: {}
+
+storageMappings:
+  "": { stores: [{ provider: S3, bucket: a-bucket }] }

--- a/ops-catalog/mock-tasks.flow.yaml
+++ b/ops-catalog/mock-tasks.flow.yaml
@@ -1,0 +1,107 @@
+# This file exists for two reasons:
+# - For prod.flow.yaml: to work around the lack of support for foreign entity resolution in the CLI
+# - For local.flow.yaml: because locally there would be no foreign entities to resolve anyway
+#
+# This includes a task for each tenant that has stats being materialized. The shards of all but one
+# of those are disabled in order to keep the data volume down, and since they don't actually need to
+# run in order to cause stats collections to get generated.
+collections:
+  acmeCo/greetings:
+    schema: greeting-schema.yaml
+    key: [/count]
+  deepsync/greetings:
+    schema: greeting-schema.yaml
+    key: [/count]
+  fenestra/greetings:
+    schema: greeting-schema.yaml
+    key: [/count]
+  phil/greetings:
+    schema: greeting-schema.yaml
+    key: [/count]
+  rockset/greetings:
+    schema: greeting-schema.yaml
+    key: [/count]
+  wgd/greetings:
+    schema: greeting-schema.yaml
+    key: [/count]
+
+captures:
+  acmeCo/hello-world:
+    shards:
+      disable: false
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/source-hello-world:dev
+        config:
+          greetings: 5
+    bindings:
+      - resource:
+          stream: greetings
+          syncMode: incremental
+        target: acmeCo/greetings
+  deepsync/hello-world:
+    shards:
+      disable: true
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/source-hello-world:dev
+        config:
+          greetings: 5
+    bindings:
+      - resource:
+          stream: greetings
+          syncMode: incremental
+        target: deepsync/greetings
+  fenestra/hello-world:
+    shards:
+      disable: true
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/source-hello-world:dev
+        config:
+          greetings: 5
+    bindings:
+      - resource:
+          stream: greetings
+          syncMode: incremental
+        target: fenestra/greetings
+  phil/hello-world:
+    shards:
+      disable: true
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/source-hello-world:dev
+        config:
+          greetings: 5
+    bindings:
+      - resource:
+          stream: greetings
+          syncMode: incremental
+        target: phil/greetings
+  rockset/hello-world:
+    shards:
+      disable: true
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/source-hello-world:dev
+        config:
+          greetings: 5
+    bindings:
+      - resource:
+          stream: greetings
+          syncMode: incremental
+        target: rockset/greetings
+  wgd/hello-world:
+    shards:
+      disable: true
+    endpoint:
+      connector:
+        image: ghcr.io/estuary/source-hello-world:dev
+        config:
+          greetings: 5
+    bindings:
+      - resource:
+          stream: greetings
+          syncMode: incremental
+        target: wgd/greetings
+

--- a/ops-catalog/ops-log-schema.json
+++ b/ops-catalog/ops-log-schema.json
@@ -1,0 +1,38 @@
+{
+
+    "$schema": "https://json-schema.org/draft-07/schema",
+    "title": "Flow task logs",
+    "description": "Logs related to the processing of a Flow capture, derivation, or materialization",
+    "type": "object",
+    "properties": {
+        "shard": { "$ref": "ops-shard-schema.json" },
+        "ts": {
+            "description": "Timestamp corresponding to the start of the transaction",
+            "type": "string",
+            "format": "date-time"
+        },
+        "level": {
+            "enum": [
+                "debug",
+                "info",
+                "warn",
+                "error"
+            ]
+        },
+        "fields": {
+            "description": "Map of keys and values that are associated with this log entry.",
+            "type": "object",
+            "additionalProperties": true
+        },
+        "message": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "shard",
+        "ts",
+        "level",
+        "message"
+    ]
+
+}

--- a/ops-catalog/ops-shard-schema.json
+++ b/ops-catalog/ops-shard-schema.json
@@ -1,0 +1,37 @@
+{
+
+    "$schema": "https://json-schema.org/draft-07/schema",
+    "title": "Flow shard id",
+    "description": "Identifies a specific shard of a task, which may be the source of a log message or metrics",
+    "type": "object",
+    "properties": {
+        "kind": {
+            "description": "The type of the catalog task",
+            "enum": [
+                "capture",
+                "derivation",
+                "materialization"
+            ]
+        },
+        "name": {
+            "description": "The name of the catalog task (without the task type prefix)",
+            "type": "string"
+        },
+        "keyBegin": {
+            "description": "The inclusive beginning of the shard's assigned key range",
+            "type": "string",
+            "pattern": "[0-9A-F]{8}"
+        },
+        "rClockBegin": {
+            "description": "The inclusive beginning of the shard's assigned rClock range",
+            "type": "string",
+            "pattern": "[0-9A-F]{8}"
+        }
+    },
+    "required": [
+        "kind",
+        "name",
+        "keyBegin",
+        "rClockBegin"
+    ]
+}

--- a/ops-catalog/ops-stats-schema.json
+++ b/ops-catalog/ops-stats-schema.json
@@ -1,0 +1,144 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema",
+    "title": "Flow task stats",
+    "description": "Statistics related to the processing of a Flow capture, derivation, or materialization",
+    "type": "object",
+    "properties": {
+        "shard": { "$ref": "ops-shard-schema.json" },
+        "ts": {
+            "description": "Timestamp corresponding to the start of the transaction",
+            "type": "string",
+            "format": "date-time"
+        },
+        "openSecondsTotal": {
+            "description": "Total time that the transaction was open before starting to commit",
+            "type": "number",
+            "reduce": {"strategy": "sum"}
+        },
+        "txnCount": {
+            "description": "Total number of transactions represented by this stats document",
+            "type": "integer",
+            "reduce": {"strategy": "sum"}
+        },
+        "capture": {
+            "description": "Capture stats, organized by collection. The keys of this object are the collection names, and the values are the stats for that collection.",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "right": {
+                        "description": "Documents fed into the combiner from the source",
+                        "$ref": "#/$defs/docsAndBytes"
+                    },
+                    "out": {
+                        "$ref": "#/$defs/docsAndBytes"
+                    }
+                },
+                "reduce": {"strategy": "merge"}
+            },
+            "reduce": {"strategy": "merge"}
+        },
+        "materialize": {
+            "description": "A map of each binding source (collection name) to combiner stats for that binding",
+            "type": "object",
+            "additionalProperties": {
+                "type": "object",
+                "properties": {
+                    "left": { "$ref": "#/$defs/docsAndBytes" },
+                    "right": { "$ref": "#/$defs/docsAndBytes" },
+                    "out": { "$ref": "#/$defs/docsAndBytes" }
+                },
+                "reduce": {"strategy": "merge"}
+            },
+            "reduce": {"strategy": "merge"}
+        },
+        "derive": {
+            "type": "object",
+            "properties": {
+                "transforms": {
+                    "description": "A map of each transform (transform name, not collection name) to stats for that transform",
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/$defs/transformStats"
+                    },
+                    "reduce": {"strategy": "merge"}
+                },
+                "registers": {"$ref": "#/$defs/registerStats"},
+                "out": { "$ref": "#/$defs/docsAndBytes" }
+            },
+            "required": ["transforms", "out"],
+            "reduce": {"strategy": "merge"}
+        }
+    },
+    "reduce": {"strategy": "merge"},
+    "required": ["shard", "ts", "txnCount", "openSecondsTotal"],
+    "oneOf": [
+        {"required": ["capture"]},
+        {"required": ["derive"]},
+        {"required": ["materialize"]}
+    ],
+    "$defs": {
+        "docsAndBytes": {
+            "type": "object",
+            "properties": {
+                "docsTotal": {
+                    "description": "Total number of documents",
+                    "type": "integer",
+                    "reduce": {"strategy": "sum"}
+                },
+                "bytesTotal": {
+                    "description": "Total number of bytes representing the JSON encoded documents",
+                    "type": "integer",
+                    "reduce": {"strategy": "sum"}
+                }
+            },
+            "reduce": {"strategy": "merge"},
+            "required": [ "docsTotal", "bytesTotal" ]
+        },
+        "registerStats": {
+            "type": "object",
+            "properties": {
+                "createdTotal": {
+                    "description": "The total number of new register keys that were created",
+                    "type": "integer",
+                    "reduce": {"strategy": "sum"}
+                }
+            },
+            "required": ["createdTotal"],
+            "reduce": {"strategy": "merge"}
+        },
+        "invokeStats": {
+            "type": "object",
+            "properties": {
+                "out": {"$ref": "#/$defs/docsAndBytes"},
+                "secondsTotal": {"type": "number"}
+            },
+            "required": ["out", "secondsTotal"],
+            "reduce": {"strategy": "merge"}
+        },
+        "transformStats": {
+            "description": "Stats for a specific transform of a derivation, which will have an update, publish, or both.",
+            "type": "object",
+            "properties": {
+                "input": {
+                    "description": "The input documents that were fed into this transform.",
+                    "$ref": "#/$defs/docsAndBytes"
+                },
+                "update": {
+                    "description": "The outputs from update lambda invocations, which were combined into registers.",
+                    "$ref": "#/$defs/invokeStats"
+                },
+                "publish": {
+                    "description": "The outputs from publish lambda invocations.",
+                    "$ref": "#/$defs/invokeStats"
+                }
+            },
+            "required": ["input"],
+            "anyOf": [
+                {"required": ["update"]},
+                {"required": ["publish"]}
+            ],
+            "reduce": {"strategy": "merge"}
+        }
+    }
+}

--- a/ops-catalog/package.json
+++ b/ops-catalog/package.json
@@ -1,0 +1,34 @@
+{
+  "dependencies": {},
+  "bundledDependencies": [],
+  "bin": "dist/flow_generated/flow/main.js",
+  "description": "NodeJS runtime of an Estuary catalog",
+  "devDependencies": {
+    "@types/node": "^14.17.5",
+    "@typescript-eslint/eslint-plugin": "^4.28.3",
+    "@typescript-eslint/parser": "^4.28.3",
+    "eslint": "^7.30.0",
+    "eslint-config-prettier": "^7.2",
+    "eslint-plugin-prettier": "^3.4.0",
+    "prettier": "^2.3.2",
+    "typescript": "^4.3.5"
+  },
+  "engines": {
+    "node": ">=10.10"
+  },
+  "enginesStrict": true,
+  "files": [
+    "dist",
+    "node_modules"
+  ],
+  "license": "UNLICENSED",
+  "name": "catalog-js-transformer",
+  "private": true,
+  "scripts": {
+    "clean": "rm -r dist/",
+    "compile": "tsc",
+    "develop": "node dist/flow_generated/flow/main.js",
+    "lint": "cd flow_generated && eslint --fix $(jq '.files[]' -r tsconfig-files.json)"
+  },
+  "version": "0.0.0"
+}

--- a/ops-catalog/prod.flow.yaml
+++ b/ops-catalog/prod.flow.yaml
@@ -1,0 +1,59 @@
+import:
+  - derivations.flow.yaml
+  # mock-tasks are included here because foreign entity resolution is not yet working for the CLI.
+  - mock-tasks.flow.yaml
+
+materializations:
+  estuary/ops/task-stats/to-postgres:
+    shards:
+      logLevel: info
+      # Keep transactions open a little longer, because we have lots of stats documents to process,
+      # and a relatively small number of distinct keys. So we're likely to do lots of reductions if
+      # we give it a little time.
+      minTxnDuration: 30s
+      maxTxnDuration: 1m
+    endpoint:
+      flowSink:
+        image: ghcr.io/estuary/materialize-postgres:dev
+        config: stats-materialization-endpoint.sops.yaml
+
+    bindings:
+      - source: estuary/ops/task-stats/by-minute
+        resource:
+          table: task_stats_by_minute
+        fields:
+          recommended: false
+          include:
+            kind: {}
+            name: {}
+            key_begin: {}
+            rclock_begin: {}
+            ts: {}
+            flow_document: {}
+      - source: estuary/ops/task-stats/by-hour
+        resource:
+          table: task_stats_by_hour
+        fields:
+          recommended: false
+          include:
+            kind: {}
+            name: {}
+            key_begin: {}
+            rclock_begin: {}
+            ts: {}
+            flow_document: {}
+      - source: estuary/ops/task-stats/by-day
+        resource:
+          table: task_stats_by_day
+        fields:
+          recommended: false
+          include:
+            kind: {}
+            name: {}
+            key_begin: {}
+            rclock_begin: {}
+            ts: {}
+            flow_document: {}
+
+storageMappings:
+  "": { stores: [{ provider: GCS, bucket: estuary-flow-poc }] }

--- a/ops-catalog/stats-materialization-endpoint.sops.yaml
+++ b/ops-catalog/stats-materialization-endpoint.sops.yaml
@@ -1,0 +1,19 @@
+database: ENC[AES256_GCM,data:nSrucwvDvPk=,iv:Fd1CYEg5BC0z4mIBS1cUuHDABj/SNOWq9bRQcr+rAEg=,tag:gxg46zewzUxpfIsQCu8A7Q==,type:str]
+host: ENC[AES256_GCM,data:8THoWpsblU4FePdlblBnbl+sRot5mf2SSOQVkZaxOh757zo=,iv:ZnHIP/cUY857hztGtW38F6flMegNEVUYF3zxsgmqw9U=,tag:2HyZB9/SjIm7I+vTUOySXA==,type:str]
+password: ENC[AES256_GCM,data:EbOQMnl6yptJk4wGBHVmjX6HTH4UjiZm1MVPP2MNL+uJAp6FyfY6S24sXQo=,iv:F+14YE/d3MXn/PwGGZD9kSnxXcWpEhfJgOQj8ZMShmE=,tag:q5YKo3jS8jtNJY3n017rcQ==,type:str]
+port: ENC[AES256_GCM,data:/zBkow==,iv:aEPMO9fO60WRc0Qn8ypF7IsIdpCdkfQLXNSwTnfwNnQ=,tag:4f0l9PnZMnoOHa+SA32/xg==,type:int]
+user: ENC[AES256_GCM,data:5IGJIcr3WOY=,iv:tqUQqJwgtGSs6kOF5kdeOpmNMzSPyjlurxR1uzbjTns=,tag:6iScNtUWMj+ciQz2nIWlRg==,type:str]
+sops:
+    kms: []
+    gcp_kms:
+        - resource_id: projects/helpful-kingdom-273219/locations/us-central1/keyRings/catalog-sops/cryptoKeys/estuary-poc
+          created_at: "2022-04-05T19:47:24Z"
+          enc: CiQAKdYibeudt+BdOjuUqjSUTGP4rMOjGQJBcOON5yWCHAPgciUSSQCOl0jkfqgIgdBm8jVBwLTQpB8EBy0JH0K3rsm3KuCR7AqAm1ciK0gsMhytM1z6mBhkol81RIku6C1dP7+6jhxXJMqk5dkqq9A=
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2022-04-12T16:32:54Z"
+    mac: ENC[AES256_GCM,data:X8CjcaBFydm2YfHXqN4F20LUxhZ9WR2zLIAOVAV80HbqpmfxbqjjSUIKHPlxLOBBQCKYJp/6J+Yh+B73mL6rG3ftMfPk2owdDuoTZDzSeWGwIC3sZ8ioSxoYRItZpg9XYhfJuRh73GwYftcewW/a45L3AndQpwRzlk6oV1iofV0=,iv:ntzkMNp1AJIbGzO5lV7mz5WXENAp/aCvr+EHt9CrRIQ=,tag:Gt/6NB0T6oiS59dcdVpYQw==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.7.1

--- a/supabase/migrations/10_stats.sql
+++ b/supabase/migrations/10_stats.sql
@@ -1,0 +1,89 @@
+-- This migration creates the tables needed for materialization of task stats into the control
+-- plane.
+
+-- We start by creating the flow_checkpoints_v1 and flow_materializations_v2 tables that are used by
+-- the materialization connector. We do this only so that we can restrict access to those tables
+-- from within this migration, instead of needing to do that manually after the materialization is
+-- applied. The create table statements were copied verbatim from the connector's output.
+
+-- This table holds Flow processing checkpoints used for exactly-once processing of materializations
+CREATE TABLE IF NOT EXISTS flow_checkpoints_v1 (
+	-- The name of the materialization.
+	materialization TEXT NOT NULL,
+	-- The inclusive lower-bound key hash covered by this checkpoint.
+	key_begin BIGINT NOT NULL,
+	-- The inclusive upper-bound key hash covered by this checkpoint.
+	key_end BIGINT NOT NULL,
+	-- This nonce is used to uniquely identify unique process assignments of a shard and prevent them from conflicting.
+	fence BIGINT NOT NULL,
+	-- Checkpoint of the Flow consumer shard, encoded as base64 protobuf.
+	checkpoint TEXT,
+
+	PRIMARY KEY(materialization, key_begin, key_end)
+);
+-- RLS is enabled to prevent clients from viewing or altering the state of materializations.
+alter table flow_checkpoints_v1 enable row level security;
+
+-- This table is the source of truth for all materializations into this system.
+CREATE TABLE IF NOT EXISTS flow_materializations_v2 (
+	-- The name of the materialization.
+	materialization TEXT NOT NULL,
+	-- Version of the materialization.
+	version TEXT NOT NULL,
+	-- Specification of the materialization, encoded as base64 protobuf.
+	spec TEXT NOT NULL,
+
+	PRIMARY KEY(materialization)
+);
+-- RLS is enabled to prevent clients from viewing or altering the state of materializations.
+alter table flow_materializations_v2 enable row level security;
+
+create type task_type as enum ('capture', 'derivation', 'materialization');
+
+-- The `task_stats_*` tables are _not_ identical to what the connector would have created.
+-- They have slightly different column types to make things a little more ergonomic and consistent.
+
+create table task_stats_by_minute (
+    kind task_type not null,
+    name catalog_name not null,
+    key_begin char(8) not null,
+    rclock_begin char(8) not null,
+    ts timestamptz not null,
+    -- We're using the JSON column type here instead of JSONB because our postgres materialization
+    -- connector fails to insert into JSONB columns for some reason. See:
+    -- https://github.com/estuary/connectors/issues/163
+    -- In any case, plain JSON seems fine for now, since we are primarily just reading or writing
+    -- the complete document. Note that we cannot use the json_obj domain type here because the Go
+    -- postgres driver seems to choke on it for some reason.
+    flow_document json not null,
+
+    primary key (name, key_begin, rclock_begin, ts)
+);
+
+comment on table task_stats_by_minute is
+    'stats for each task shard aggregated by the minute';
+comment on column task_stats_by_minute.kind is
+    'the type of task to which the stats pertain';
+comment on column task_stats_by_minute.name is
+    'Name of the task';
+comment on column task_stats_by_minute.key_begin is
+    'The beginning of the key range that is served by the shard';
+comment on column task_stats_by_minute.rclock_begin is
+    'The beginning of the rclock range that is served by the shard';
+comment on column task_stats_by_minute.ts is
+    'The UTC timestamp corresponding to the beginning of the time range for the stats document';
+comment on column task_stats_by_minute.flow_document is
+    'Complete stats document';
+
+grant select on task_stats_by_minute to authenticated;
+
+create table task_stats_by_hour (like task_stats_by_minute including all);
+comment on table task_stats_by_hour is
+    'stats for each task shard aggregated by the hour';
+grant select on task_stats_by_hour to authenticated;
+
+create table task_stats_by_day (like task_stats_by_minute including all);
+comment on table task_stats_by_day is
+    'stats for each task shard aggregated by the day';
+grant select on task_stats_by_day to authenticated;
+


### PR DESCRIPTION
This adds a database migration that adds new tables to hold flow task
stats, and a flow catalog that materializes the stats to those tables.
The resulting tables can be queried via the REST API.