### PR TITLE
Adding a setup replication script

### DIFF
--- a/scripts/setup_replication.sql
+++ b/scripts/setup_replication.sql
@@ -1,0 +1,20 @@
+
+-- This script is used to setup replication for the tables
+-- the UI uses subscriptions for. Without this the UI will
+-- never be sent messages about changes.
+--
+-- To run: run inside the SQL Editor
+
+begin;
+
+-- Drop the current realtime replication
+drop publication if exists supabase_realtime; 
+
+-- Create the realtime replication
+create publication supabase_realtime;  
+
+-- Setup the tables the UI uses subscriptions with
+alter publication supabase_realtime add table discovers;
+alter publication supabase_realtime add table publications;
+  
+commit;


### PR DESCRIPTION
We need to get replication setup anytime we blow away and reset the Supabase API. Putting this into a script to make it easier to grab out and run in the SQL Editor. Eventually it would be great to work this into the migrations.

I based this one off of the `seed_connectors` script. I removed the line on how to run the file cause I just ran this in the editor. If that is needed please let me know the proper command. I assume it was basically the same as the seeding one - but wasn't sure.