### PR TITLE
Generate Data Plane Gateway auth tokens

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,12 @@ Many of the agents functions involve building, testing, activating, and deleting
 
 Also required: [gsutil](https://cloud.google.com/storage/docs/gsutil), [sops](https://github.com/mozilla/sops), and [jq](https://stedolan.github.io/jq/).
 
+### Data Plane Gateway
+
+The [Data Plane Gateway](https://github.com/estuary/data-plane-gateway) serves a few endpoints which give access to Gazette RPCs. Notably, this allows querying for Shard status and directly reading Journals. This is used by the UI to check the status of a Shard.
+
+The Control Plane issues access tokens via the `gateway_auth_token` function which grants users access to selected catalog prefixes.
+
 
 ## Local Development Guide
 
@@ -57,9 +63,8 @@ supabase -v
 ```
 
 * A local checkout of [github.com/estuary/flow](github.com/estuary/flow) upon which you've run `make package`. This creates a directory of binaries `${your_checkout}/.build/package/bin/` which the control-plane agent refers to as `--bin-dir` or `$BIN_DIR`.
-
+* A local checkout of [github.com/estuary/data-plane-gateway](github.com/estuary/data-plane-gateway).
 * A local checkout of [github.com/estuary/ui](github.com/estuary/ui).
-
 * A local checkout of this repository.
 
 ### Start Supabase:
@@ -109,6 +114,25 @@ You start a `temp-data-plane` which runs a local instance of `etcd`, a `gazette`
 ```
 
 A `temp-data-plane` runs the same components and offers identical APIs to a production data plane with one key difference: unlike a production data-plane, `temp-data-plane` is ephemeral and will not persist fragment data to cloud storage regardless of [JournalSpec](https://gazette.readthedocs.io/en/latest/brokers-journalspecs.html) configuration. When you stop `temp-data-plane` it discards all journal and shard specifications and fragment data. Starting a new `temp-data-plane` is then akin to bringing up a brand new, empty cluster.
+
+### Start the `data-plane-gateway`:
+
+Build the `data-plane-gateway` binary:
+
+```console
+cd data-plane-gateway/
+go install .
+```
+
+_Note: It is not necessary to install all the protoc tooling or run `make`. Those are only necessary for modifying the generated code within the gateway._
+
+Start the gateway:
+
+```console
+data-plane-gateway
+```
+
+_Note: The gateway allows for configuring the port, the Flow service ports, the signing secret, and the CORS settings. The defaults should work out of the box._
 
 ### Build `fetch-open-graph`:
 

--- a/supabase/migrations/14_gateway_auth.sql
+++ b/supabase/migrations/14_gateway_auth.sql
@@ -1,0 +1,76 @@
+-- Keys used to sign/verify gateway auth tokens.
+create table internal.gateway_auth_keys (
+  like internal._model including all,
+  -- Key used to sign JWTs
+  secret_key text
+);
+
+insert into internal.gateway_auth_keys (secret_key, detail) values (
+  'supersecret', 'Used for development only. This value will be changed manually when deployed to production.'
+);
+
+
+
+-- Addresses of deployed data plane gateways. As we deploy into multiple
+-- AZs/Regions, we can direct a caller to the appropriate Gateway for accessing
+-- data in a region-aware way.
+create table internal.gateway_endpoints (
+  like internal._model including all,
+  name text,
+  url text
+);
+
+insert into internal.gateway_endpoints (name, url, detail) values (
+  'local', 'http://localhost:28318/', 'Used for development only. This value will be changed manually when deployed to production.'
+);
+
+
+
+-- Returns the most appropriate gateway url. For now, there should only be one.
+create function internal.gateway_endpoint_url()
+returns text as $$
+
+  select url
+  from internal.gateway_endpoints
+  limit 1
+
+$$ language sql stable security definer;
+
+
+
+-- Grabs the secret signing key and signs the object.
+create function internal.sign_jwt(obj json)
+returns text as $$
+
+  select sign(obj, secret_key::text)
+  from internal.gateway_auth_keys
+  limit 1
+
+$$ language sql stable security definer;
+
+
+
+create function gateway_auth_token(variadic prefixes text[])
+returns table (token text, gateway_url text) as $$
+
+  with authorized_prefixes as (
+    select p as prefix
+    from auth_roles() as r, unnest(prefixes) as p
+    where starts_with(p, r.role_prefix)
+  )
+
+  select internal.sign_jwt(
+    json_build_object(
+      'exp', trunc(extract(epoch from (now() + interval '1 hour'))),
+      'iat', trunc(extract(epoch from (now()))),
+      'operation', 'read',
+      'prefixes', array_agg(distinct ap.prefix),
+      'sub', auth_uid()
+    )
+  ) as token, internal.gateway_endpoint_url() as gateway_url
+  from authorized_prefixes as ap
+
+$$ language sql stable security definer;
+
+comment on function gateway_auth_token is
+  'gateway_auth_token returns a jwt that can be used with the Data Plane Gateway to interact directly with Gazette RPCs.';


### PR DESCRIPTION
Adds the `gateway_auth_token` rpc. This will use the user's role prefixes to generate a JWT (with [`pgjwt`](https://github.com/michelp/pgjwt) pre-installed by Supabase) that can be passed to the Data Plane Gateway. We only support `read` operations right now, as it isn't clear how a user can usefully use the other Gazette endpoints. Tokens expire after an hour, but this was arbitrary.

This also adds a couple of internal tables for configuring the behavior of this token. If there's a better way to handling injecting configuration/secrets into postgres functions, I'm all ears.