### PR TITLE
build and push to container registry

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -2,7 +2,7 @@ name: Estuary Control-Plane CI/CD
 
 # Controls when the action will run. Triggers the workflow on push
 # or pull request events, but only for the primary branch.
-on: [push,pull_request]
+on: [push]
 
 jobs:
   build:


### PR DESCRIPTION
This: 

* Launches supabase
* Sets up go & caches
* Sets up a docker build env
* Builds and pushes to the container registry with the short sha on all pushes/pr's
* Builds and pushes to the container registry with the latest tag and short sha on main merges.

This has been tested on another branch and works after getting with Github support to find a permissions error. 