### PR TITLE
add `last_build_id` to `live_specs` to resolve phantom deletions

### DIFF
--- a/crates/agent/src/connector_tags.rs
+++ b/crates/agent/src/connector_tags.rs
@@ -111,7 +111,8 @@ impl TagHandler {
                 .arg("-url")
                 .arg(&row.external_url)
                 .output()
-                .await?;
+                .await
+                .context("fetching open graph metadata")?;
 
         if !fetch_open_graph.status.success() {
             return Ok((

--- a/crates/agent/src/publications/specs.rs
+++ b/crates/agent/src/publications/specs.rs
@@ -58,6 +58,7 @@ pub async fn resolve_specifications(
     // as if the spec is being created.
     for row in &mut spec_rows {
         if row.user_capability.is_none() {
+            row.last_build_id = pub_id;
             row.last_pub_id = pub_id;
             row.live_spec = None;
             row.live_spec_id = row.draft_spec_id;
@@ -179,6 +180,7 @@ pub fn validate_transition(
         draft_spec_id: _,
         draft_type,
         expect_pub_id,
+        last_build_id: _,
         last_pub_id,
         live_spec: _,
         live_spec_id: _,
@@ -350,6 +352,7 @@ pub async fn apply_updates_for_row(
         draft_spec_id,
         draft_type,
         expect_pub_id: _,
+        last_build_id: _,
         last_pub_id: _,
         live_spec: _,
         live_spec_id,
@@ -393,7 +396,7 @@ pub async fn apply_updates_for_row(
 
     let (reads_from, writes_to, image_parts) = extract_spec_metadata(catalog, spec_row);
 
-    agent_sql::publications::update_live_spec(
+    agent_sql::publications::update_published_live_spec(
         catalog_name,
         image_parts.as_ref().map(|p| &p.0),
         image_parts.as_ref().map(|p| &p.1),
@@ -436,6 +439,7 @@ fn extract_spec_metadata<'a>(
         draft_spec_id: _,
         draft_type,
         expect_pub_id: _,
+        last_build_id: _,
         last_pub_id: _,
         live_spec: _,
         live_spec_id: _,

--- a/supabase/migrations/09_publications.sql
+++ b/supabase/migrations/09_publications.sql
@@ -44,6 +44,7 @@ create table live_specs (
   catalog_name          catalog_name not null,
   connector_image_name  text,
   connector_image_tag   text,
+  last_build_id         flowid not null,
   last_pub_id           flowid not null,
   reads_from            text[],
   spec                  json,
@@ -76,6 +77,15 @@ comment on column live_specs.connector_image_name is
   'OCI (Docker) connector image name used by this specification';
 comment on column live_specs.connector_image_tag is
   'OCI (Docker) connector image tag used by this specification';
+comment on column live_specs.last_build_id is '
+Last publication ID under which this specification was built and activated
+into the data-plane, even if it was not necessarily updated.
+
+A specification may be included in a publication which did not directly
+change it simply because of its connection to other specifications which
+were part of that publication: Flow identifies connected specifications
+in order to holistically verify and test their combined behaviors.
+';
 comment on column live_specs.last_pub_id is
   'Last publication ID which updated this specification';
 comment on column live_specs.reads_from is '

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -77,7 +77,7 @@ begin
     'https://estuary.dev'
   )
   returning id strict into connector_id;
-  insert into connector_tags (connector_id, image_tag) values (connector_id, ':dev');
+  insert into connector_tags (connector_id, image_tag) values (connector_id, ':v1');
 
   insert into connectors (image_name, detail, external_url) values (
     'ghcr.io/estuary/source-postgres',
@@ -85,7 +85,7 @@ begin
     'https://postgresql.org'
   )
   returning id strict into connector_id;
-  insert into connector_tags (connector_id, image_tag) values (connector_id, ':dev');
+  insert into connector_tags (connector_id, image_tag) values (connector_id, ':v1');
 
   insert into connectors (image_name, detail, external_url) values (
     'ghcr.io/estuary/materialize-postgres',
@@ -93,7 +93,7 @@ begin
     'https://postgresql.org'
   )
   returning id strict into connector_id;
-  insert into connector_tags (connector_id, image_tag) values (connector_id, ':dev');
+  insert into connector_tags (connector_id, image_tag) values (connector_id, ':v1');
 
 end;
 $$ language plpgsql;


### PR DESCRIPTION
`last_build_id` is the publication which last caused a spec to be built
and activated into the data-plane.

Update publication behavior to keep this column up-to-date given the
expanded set of catalog specifications.

Use `last_build_id` to identify the correct build DB for data-plane
deletions.

Tested:
  * Started a local control-plane + data-plane, with a side Postgres DB
  * Create a capture and multiple materializations over a period of time,
    with staggered deletions of materializations while creating others.
  * Deleted all remaining tasks, and verified that all ApplyDelete RPCs
    were run and all shards were removed, leaving an empty data-plane.

Issue #24