### PR TITLE
Ensure Builds Persist

### DIFF
--- a/scripts/seed_connectors.sql
+++ b/scripts/seed_connectors.sql
@@ -182,6 +182,14 @@ begin
   returning id strict into connector_id;
   insert into connector_tags (connector_id, image_tag) values (connector_id, ':0.1.0');
 
+  insert into connectors (image_name, detail, external_url) values (
+    'ghcr.io/estuary/source-http-file',
+    'Capture from any single file',
+    'https://go.estuary.dev/source-http-file'
+  )
+  returning id strict into connector_id;
+  insert into connector_tags (connector_id, image_tag) values (connector_id, ':dev');
+
 end;
 $$ language plpgsql;
 


### PR DESCRIPTION
This ensures the build database exists in cloud storage in the event that we fail to inspect the `errors` table. This is indicative of a bug elsewhere, but it's difficult to investigate when the database isn't uploaded.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/animated-carnival/37)
<!-- Reviewable:end -->
