### PR TITLE
Add config-encryption service to local instance

### DIFF
--- a/local/start-component.sh
+++ b/local/start-component.sh
@@ -13,6 +13,9 @@ CONSUMER_PORT=9000
 export BROKER_ADDRESS=http://localhost:$BROKER_PORT
 export CONSUMER_ADDRESS=http://localhost:$CONSUMER_PORT
 
+# The kms key used by the local config-encryption. All of estuary engineering should have access to this key.
+TEST_KMS_KEY=projects/helpful-kingdom-273219/locations/us-central1/keyRings/dev/cryptoKeys/testing
+
 function log() {
     echo -e "$@" 1>&2
 }
@@ -54,6 +57,11 @@ function project_dir() {
     else
         echo "$ANIMATED_CARNIVAL_PARENT_DIR/$project"
     fi
+}
+
+function start_config_encryption() {
+    cd "$(project_dir 'config-encryption')"
+    must_run cargo run -- --gcp-kms "$TEST_KMS_KEY"
 }
 
 function start_ui() {
@@ -114,6 +122,9 @@ case "$1" in
         ;;
     control-plane-agent)
         start_control_plane_agent
+        ;;
+    config-encryption)
+        start_config_encryption
         ;;
     *)
         bail "Invalid argument: '$1'"

--- a/local/start-flow.sh
+++ b/local/start-flow.sh
@@ -65,7 +65,7 @@ log "Created new tmux session called '$SESSION'"
 # tmux seems to always create a window automatically
 tmux send-keys -t "=${SESSION}:=terminal" 'echo Use this terminal for whatever you want' Enter
 
-flow_components=("temp-data-plane" "control-plane" "ui" "control-plane-agent" "data-plane-gateway")
+flow_components=("temp-data-plane" "control-plane" "ui" "control-plane-agent" "data-plane-gateway" "config-encryption")
 for component in ${flow_components[@]}; do
     start_component "$component"
 done

--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,7 @@ supabase -v
 * A local checkout of [github.com/estuary/flow](github.com/estuary/flow) upon which you've run `make package`. This creates a directory of binaries `${your_checkout}/.build/package/bin/` which the control-plane agent refers to as `--bin-dir` or `$BIN_DIR`.
 * A local checkout of [github.com/estuary/data-plane-gateway](github.com/estuary/data-plane-gateway).
 * A local checkout of [github.com/estuary/ui](github.com/estuary/ui).
+* A local checkout of [github.com/estuary/config-encryption](github.com/estuary/config-encryption).
 * A local checkout of this repository.
 
 ### Start Supabase:


### PR DESCRIPTION
Previously, a locally running Flow instance would still use the
production config-encryption service. This fixes that so a local
instance of config-encryption is run alongside the other services.
This will require a complimentary PR in the UI to point the local
UI to the local config-encryption service.

Fixes #38

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/animated-carnival/39)
<!-- Reviewable:end -->
