### PR TITLE
Fix start-component.sh to use flowctl-admin

### DIFF
--- a/local/start-component.sh
+++ b/local/start-component.sh
@@ -65,7 +65,7 @@ function start_ui() {
 function start_data_plane() {
     cd "$(project_dir 'flow')"
     must_run make package
-    must_run ./.build/package/bin/flowctl temp-data-plane --log.level=info
+    must_run ./.build/package/bin/flowctl-admin temp-data-plane --log.level=info
 }
 
 function start_data_plane_gateway() {


### PR DESCRIPTION
Use `flowctl-admin` to start the `temp-data-plane` in `start-component.sh`.

Building from scratch, I found that the `start-flow.sh` script was failing because `flowctl` could not be found, and this fixed it for me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/animated-carnival/41)
<!-- Reviewable:end -->
