### PR TITLE
docs: Add missing `go build` command to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -116,6 +116,7 @@ Build the `data-plane-gateway` binary:
 ```console
 cd data-plane-gateway/
 go install .
+go build .
 ```
 
 _Note: It is not necessary to install all the protoc tooling or run `make`. Those are only necessary for modifying the generated code within the gateway._


### PR DESCRIPTION
Having not used `go` in many years, I got confused when I followed the instructions, and there was no `data-plane-gateway` binary. Turns out you need to run `go build` to get it!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/animated-carnival/46)
<!-- Reviewable:end -->
