### PR TITLE
fix: Add optional chaining to prevent exceptions when `config` is missing

### DIFF
--- a/supabase/functions/oauth/encrypt-config.ts
+++ b/supabase/functions/oauth/encrypt-config.ts
@@ -28,7 +28,7 @@ export async function encryptConfig(req: Record<string, any>) {
 
   const { oauth2_client_id, oauth2_client_secret } = data;
 
-  if (config[CREDENTIALS_KEY]["client_id"] == CLIENT_CREDS_INJECTION && config[CREDENTIALS_KEY]["client_secret"] == CLIENT_CREDS_INJECTION) {
+  if (config?.[CREDENTIALS_KEY]?.["client_id"] === CLIENT_CREDS_INJECTION && config?.[CREDENTIALS_KEY]?.["client_secret"] === CLIENT_CREDS_INJECTION) {
     config[CREDENTIALS_KEY]["client_id"] = oauth2_client_id;
     config[CREDENTIALS_KEY]["client_secret"] = oauth2_client_secret;
   }


### PR DESCRIPTION
I ran into this when getting started with Flow locally on a call today with @travjenkins, and this is the fix we came up with. I haven't fully read all of this code, so if this fix is actually not the right thing to do, please let me know :)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/animated-carnival/48)
<!-- Reviewable:end -->
