### PR TITLE
oauth2: allow injecting arbitrary values to connector for oauth2

### DIFF
--- a/supabase/functions/oauth/access-token.ts
+++ b/supabase/functions/oauth/access-token.ts
@@ -14,7 +14,7 @@ export async function accessToken(req: Record<string, any>) {
 
   const { data, error } = await supabaseClient
     .from("connectors")
-    .select("oauth2_client_id,oauth2_client_secret,oauth2_spec")
+    .select("oauth2_client_id,oauth2_client_secret,oauth2_injected_values,oauth2_spec")
     .eq("id", connector_id)
     .single();
 
@@ -22,7 +22,7 @@ export async function accessToken(req: Record<string, any>) {
     returnPostgresError(error);
   }
 
-  const { oauth2_spec, oauth2_client_id, oauth2_client_secret } = data;
+  const { oauth2_spec, oauth2_client_id, oauth2_injected_values, oauth2_client_secret } = data;
 
   const urlTemplate = Handlebars.compile(oauth2_spec.accessTokenUrlTemplate);
   const url = urlTemplate({
@@ -30,6 +30,7 @@ export async function accessToken(req: Record<string, any>) {
     client_id: oauth2_client_id,
     client_secret: oauth2_client_secret,
     config,
+    ...oauth2_injected_values,
     ...params,
   });
 
@@ -41,6 +42,7 @@ export async function accessToken(req: Record<string, any>) {
     client_id: oauth2_client_id,
     client_secret: oauth2_client_secret,
     config,
+    ...oauth2_injected_values,
     ...params,
   });
 
@@ -55,6 +57,7 @@ export async function accessToken(req: Record<string, any>) {
         client_id: oauth2_client_id,
         client_secret: oauth2_client_secret,
         config,
+        ...oauth2_injected_values,
         ...params,
       })
     );

--- a/supabase/migrations/06_connectors.sql
+++ b/supabase/migrations/06_connectors.sql
@@ -3,15 +3,16 @@
 create table connectors (
   like internal._model including all,
 
-  external_url         text not null,
-  image_name           text unique not null,
-  open_graph           jsonb_obj
+  external_url           text not null,
+  image_name             text unique not null,
+  open_graph             jsonb_obj
     generated always as (internal.jsonb_merge_patch(open_graph_raw, open_graph_patch)) stored,
-  open_graph_raw       jsonb_obj,
-  open_graph_patch     jsonb_obj,
-  oauth2_client_id     text,
-  oauth2_client_secret text,
-  oauth2_spec          jsonb_obj,
+  open_graph_raw         jsonb_obj,
+  open_graph_patch       jsonb_obj,
+  oauth2_client_id       text,
+  oauth2_client_secret   text,
+  oauth2_injected_values jsonb_obj,
+  oauth2_spec            jsonb_obj,
   --
   constraint "image_name must be a container image without a tag"
     check (image_name ~ '^(?:.+/)?([^:]+)$')
@@ -37,6 +38,8 @@ comment on column connectors.oauth2_client_id is
   'oauth client id';
 comment on column connectors.oauth2_client_secret is
   'oauth client secret';
+comment on column connectors.oauth2_injected_values is
+  'oauth additional injected values, these values will be made available in the credentials key of the connector, as well as when rendering oauth2_spec templates';
 comment on column connectors.oauth2_spec is
   'OAuth2 specification of the connector';
 

--- a/supabase/pending/oauth.sql
+++ b/supabase/pending/oauth.sql
@@ -1,28 +1,5 @@
--- OAuth Client ID and Client Secret are associated uniquely with
--- connectors.
-alter table if exists connectors
-    add column oauth2_client_id text collate pg_catalog."default";
+ALTER TABLE IF EXISTS public.connectors
+    ADD COLUMN oauth2_injected_values jsonb_obj;
 
-comment on column connectors.oauth2_client_id
-    is 'oauth client id';
-
-alter table if exists connectors
-    add column oauth2_client_secret text collate pg_catalog."default";
-
-comment on column connectors.oauth2_client_secret
-    is 'oauth client secret';
-
--- The client secret must not be accessible by clients, and only priviledged
--- services must be able to access such secret.
-revoke select on connectors from authenticated;
-grant select(id, detail, external_url, image_name, open_graph, created_at, updated_at, oauth2_client_id) on connectors to authenticated;
-
-
--- The new OAuth2Spec part of SpecResponse for connectors should also be persisted
--- see https://github.com/estuary/flow/pull/570/files
-
-alter table if exists connectors
-    add column oauth2_spec json_obj;
-
-comment on column connectors.oauth2_spec is
-  'OAuth2 specification of the connector';
+COMMENT ON COLUMN public.connectors.oauth2_injected_values
+    IS 'oauth additional injected values, these values will be made available in the credentials key of the connector, as well as when rendering oauth2_spec templates';


### PR DESCRIPTION
Allow injecting arbitrary secret keys into credentials and templates.

One potential change here is to consolidate `client_id` and `client_secret` into the same `oauth2_injected_values`, what do you folks think?

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/animated-carnival/50)
<!-- Reviewable:end -->
