### PR TITLE
oauth2: allow non-json access token bodies

### DIFF
--- a/supabase/functions/oauth/access-token.ts
+++ b/supabase/functions/oauth/access-token.ts
@@ -35,7 +35,7 @@ export async function accessToken(req: Record<string, any>) {
   });
 
   const bodyTemplate = Handlebars.compile(
-    JSON.stringify(oauth2_spec.accessTokenBody)
+    oauth2_spec.accessTokenBody
   );
   const body = bodyTemplate({
     redirect_uri,


### PR DESCRIPTION
depends on: https://github.com/estuary/flow/pull/633

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/animated-carnival/52)
<!-- Reviewable:end -->
