### PR TITLE
oauth: add "urlencode" helper to handlebars templates

### DIFF
--- a/supabase/functions/_shared/helpers.ts
+++ b/supabase/functions/_shared/helpers.ts
@@ -9,3 +9,9 @@ export const returnPostgresError = (error: any) => {
     status: 400,
   });
 };
+
+export const handlebarsHelpers = {
+  urlencode: function(s: string) {
+    return encodeURIComponent(s)
+  }
+}

--- a/supabase/functions/oauth/access-token.ts
+++ b/supabase/functions/oauth/access-token.ts
@@ -2,12 +2,13 @@ import { serve } from "https://deno.land/std@0.131.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js";
 import Handlebars from "https://esm.sh/handlebars";
 import jsonpointer from "https://esm.sh/jsonpointer.js";
-import { returnPostgresError } from "../_shared/helpers.ts";
+import { returnPostgresError, handlebarsHelpers } from "../_shared/helpers.ts";
 import { corsHeaders } from "../_shared/cors.ts";
 import { supabaseClient } from "../_shared/supabaseClient.ts";
 
 export async function accessToken(req: Record<string, any>) {
   const { state, config, redirect_uri, ...params } = req;
+  Handlebars.registerHelper(handlebarsHelpers);
 
   const decodedState = JSON.parse(atob(state));
   const { connector_id } = decodedState;

--- a/supabase/functions/oauth/auth-url.ts
+++ b/supabase/functions/oauth/auth-url.ts
@@ -1,7 +1,7 @@
 import { createClient } from "https://esm.sh/@supabase/supabase-js";
 import Handlebars from "https://esm.sh/handlebars";
 import { corsHeaders } from "../_shared/cors.ts";
-import { returnPostgresError } from "../_shared/helpers.ts";
+import { returnPostgresError, handlebarsHelpers } from "../_shared/helpers.ts";
 import { supabaseClient } from "../_shared/supabaseClient.ts";
 
 const generateUniqueRandomKey = () => {
@@ -21,6 +21,8 @@ export async function authURL(req: {
   redirect_uri?: string;
   state?: object;
 }) {
+  Handlebars.registerHelper(handlebarsHelpers);
+
   const { connector_id, config, redirect_uri, state } = req;
 
   const { data, error } = await supabaseClient


### PR DESCRIPTION
This helper can be used in templates as:

```
{{ urlencode client_id }}
```

This is useful when sending a url encoded POST body, to escape special characters. Example usage in [salesforce](https://github.com/estuary/airbyte/commit/29d0c93f7d645e102e84e268910fe4b1c7730527).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/animated-carnival/54)
<!-- Reviewable:end -->
