### PR TITLE
use host network with start-flow.sh

### DIFF
--- a/local/start-component.sh
+++ b/local/start-component.sh
@@ -73,7 +73,7 @@ function start_ui() {
 function start_data_plane() {
     cd "$(project_dir 'flow')"
     must_run make package
-    must_run ./.build/package/bin/flowctl-admin temp-data-plane --log.level=info
+    must_run ./.build/package/bin/flowctl-admin temp-data-plane --log.level=info --network=host
 }
 
 function start_data_plane_gateway() {


### PR DESCRIPTION
I had forgotten to add that argument when I wrote the script. Without it, connectors can't connect to things running on localhost, which is a really useful capability for local testing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/animated-carnival/61)
<!-- Reviewable:end -->
