### PR TITLE
start-component.sh: Build the `fetch-open-graph` binary

### DIFF
--- a/local/start-component.sh
+++ b/local/start-component.sh
@@ -89,6 +89,10 @@ function start_control_plane() {
 }
 
 function start_control_plane_agent() {
+    local flow_bin_dir="$(project_dir 'flow')/.build/package/bin"
+    cd "$(project_dir 'animated-carnival')/fetch-open-graph"
+    go build -o "$flow_bin_dir"
+
     cd "$(project_dir 'animated-carnival')"
     # Start building immediately, since it could take a while
     must_run cargo build -p agent
@@ -102,7 +106,6 @@ function start_control_plane_agent() {
     # Use the resolved flow project directory to set the --bin-dir argument.
     # We're counting on `make package` to have completed successfully at this point, which should be
     # the case if the temp-data-plane is running.
-    local flow_bin_dir="$(project_dir 'flow')/.build/package/bin"
     export RUST_LOG=info
     must_run cargo run -p agent -- --bin-dir "$flow_bin_dir"
 }


### PR DESCRIPTION
Currently, as far as I could tell, nothing is actually responsible for building this if you just clone all the repositories and run `start-flow.sh`, so for obvious reasons things fail to start up properly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/animated-carnival/62)
<!-- Reviewable:end -->
