### PR TITLE
refactor: Add the ability to hide log output unless there was an error

### DIFF
--- a/crates/agent/src/connector_tags.rs
+++ b/crates/agent/src/connector_tags.rs
@@ -82,6 +82,7 @@ impl TagHandler {
                 "pull",
                 &self.logs_tx,
                 row.logs_token,
+                true, // Certainly don't want docker pull output unless there's an error
                 tokio::process::Command::new("docker")
                     .arg("pull")
                     .arg(&image_composed),

--- a/crates/agent/src/discovers.rs
+++ b/crates/agent/src/discovers.rs
@@ -99,6 +99,7 @@ impl DiscoverHandler {
                 "pull",
                 &self.logs_tx,
                 row.logs_token,
+                true, // Certainly don't want docker pull output unless there's a failure
                 tokio::process::Command::new("docker")
                     .arg("pull")
                     .arg(&image_composed),

--- a/crates/agent/src/logs.rs
+++ b/crates/agent/src/logs.rs
@@ -16,6 +16,26 @@ pub struct Line {
 // Tx is the channel sender of log Lines.
 pub type Tx = tokio::sync::mpsc::Sender<Line>;
 
+// Sends a single log line to the Sender
+#[tracing::instrument(err, skip(tx, line))]
+pub async fn write_line(
+    tx: Tx,
+    stream: String,
+    token: Uuid,
+    line: &str,
+) -> Result<(), std::io::Error>
+{
+    tx.send(Line {
+        token,
+        stream: stream.clone(),
+        line: line.to_string(),
+    })
+    .await
+    .unwrap();
+
+    Ok(())
+}
+
 // capture_job_logs consumes newline-delimited lines from the AsyncRead and
 // streams each as a Line to the channel Sender.
 #[tracing::instrument(err, skip(tx, reader))]

--- a/crates/agent/src/publications/builds.rs
+++ b/crates/agent/src/publications/builds.rs
@@ -39,6 +39,7 @@ pub async fn build_catalog(
         "build",
         logs_tx,
         logs_token,
+        true, // No need to log a bunch of docker output etc if the command succeeds
         tokio::process::Command::new(format!("{bindir}/flowctl-go"))
             .arg("api")
             .arg("build")
@@ -71,6 +72,7 @@ pub async fn build_catalog(
         "persist",
         &logs_tx,
         logs_token,
+        true, // No need to log a bunch of stuff about file copies if we're successful
         tokio::process::Command::new("gsutil")
             .arg("cp")
             .arg(&db_path)
@@ -120,6 +122,7 @@ pub async fn data_plane(
         "temp-data-plane",
         logs_tx,
         logs_token,
+        false, // Fairly sure we always want these logs
         tokio::process::Command::new(format!("{bindir}/flowctl-go"))
             .arg("temp-data-plane")
             .arg("--network")
@@ -166,6 +169,7 @@ pub async fn test_catalog(
         "setup",
         &logs_tx,
         logs_token,
+        false, // Logging related to testing left in
         tokio::process::Command::new(format!("{bindir}/flowctl-go"))
             .arg("api")
             .arg("activate")
@@ -197,6 +201,7 @@ pub async fn test_catalog(
         "test",
         &logs_tx,
         logs_token,
+        false, // We always want to see test results, because "23/23 tests passed" feels warm and fuzzy
         tokio::process::Command::new(format!("{bindir}/flowctl-go"))
             .arg("api")
             .arg("test")
@@ -224,6 +229,7 @@ pub async fn test_catalog(
         "cleanup",
         logs_tx,
         logs_token,
+        true, // Probably don't care about this unless it fails
         tokio::process::Command::new(format!("{bindir}/flowctl-go"))
             .arg("api")
             .arg("delete")
@@ -289,6 +295,7 @@ pub async fn deploy_build(
         "activate",
         logs_tx,
         logs_token,
+        true, // We only want to see detailed output if this fails
         tokio::process::Command::new(format!("{bindir}/flowctl-go"))
             .arg("api")
             .arg("activate")
@@ -340,6 +347,7 @@ pub async fn deploy_build(
             "delete",
             logs_tx,
             logs_token,
+            true, // We only want to see detailed output if this fails 
             tokio::process::Command::new(format!("{bindir}/flowctl-go"))
                 .arg("api")
                 .arg("delete")


### PR DESCRIPTION
This is a short-term solution for #64, where the longer term solution would be emitting structured logs and filtering elsewhere

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/animated-carnival/69)
<!-- Reviewable:end -->
