### PR TITLE
oauth: add logs to access-token in case of parsing failure

### DIFF
--- a/supabase/functions/oauth/access-token.ts
+++ b/supabase/functions/oauth/access-token.ts
@@ -77,7 +77,15 @@ export async function accessToken(req: Record<string, any>) {
 
   const accessTokenResponseMap = oauth2_spec.accessTokenResponseMap || {};
 
-  let responseData = await response.json();
+  const responseText = await response.text();
+
+  if (response.status >= 400) {
+    console.log("access token request failed");
+    console.log("request: POST ", url);
+    console.log("response: ", response.status, response.statusText, "headers: ", response.headers, "response body:", responseText);
+  }
+
+  let responseData = JSON.parse(responseText);
 
   let mappedData: Record<string, any> = {};
   for (const key in accessTokenResponseMap) {
@@ -85,10 +93,6 @@ export async function accessToken(req: Record<string, any>) {
       responseData,
       accessTokenResponseMap[key]
     );
-  }
-
-  if (response.status >= 400) {
-    console.log("access token request failed: ", responseData);
   }
 
   return new Response(JSON.stringify(mappedData), {


### PR DESCRIPTION
Sometimes the response of servers is not JSON when there is an issue. We need logs to troubleshoot such cases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/animated-carnival/70)
<!-- Reviewable:end -->
