### PR TITLE
publications: disallow re-creation of a deleted spec

### DIFF
--- a/crates/agent/src/publications/specs.rs
+++ b/crates/agent/src/publications/specs.rs
@@ -279,6 +279,18 @@ pub fn validate_transition(
                 // No constraint.
             }
         };
+
+        // Verify that the live specification has not existed and then been deleted in the past.
+        // TODO(johnny): remove once we introduce data plane pet-names.
+        if live_type.is_none() && draft_type.is_some() && *last_pub_id != pub_id   {
+                errors.push(Error {
+                    catalog_name: catalog_name.clone(),
+                    detail: format!(
+                        "A specification with this name previously existed and then was deleted. At present Flow does not allow for re-creation with this same name."
+                    ),
+                    ..Default::default()
+                });
+        }
     }
 
     for eob in draft


### PR DESCRIPTION
If a spec was published previously but is currently deleted, don't allow for it to be re-created. This is a temporary measure until we implement data plane pet-names.

Proper unit testing of this area is currently awkward: a larger project that's out of scope. Tested on a local stack by creating a capture, deleting it, and then attempting to re-create it in the UI.

Issue #65

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/animated-carnival/71)
<!-- Reviewable:end -->
