### PR TITLE
oauth: add template helper base64encode

### DIFF
--- a/supabase/functions/_shared/helpers.ts
+++ b/supabase/functions/_shared/helpers.ts
@@ -13,5 +13,11 @@ export const returnPostgresError = (error: any) => {
 export const handlebarsHelpers = {
   urlencode: function(s: string) {
     return encodeURIComponent(s)
+  },
+  base64encode: function(s: string) {
+    return btoa(s)
+  },
+  basicauth: function(user: string, pass: string) {
+    return btoa(`${user}:${pass}`)
   }
 }


### PR DESCRIPTION
add a new helper `base64encode`, since sometimes we need to encode some headers

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/animated-carnival/72)
<!-- Reviewable:end -->
