### PR TITLE
oauth: allow access token requests without body

### DIFF
--- a/supabase/functions/oauth/access-token.ts
+++ b/supabase/functions/oauth/access-token.ts
@@ -35,17 +35,20 @@ export async function accessToken(req: Record<string, any>) {
     ...params,
   });
 
-  const bodyTemplate = Handlebars.compile(
-    oauth2_spec.accessTokenBody
-  );
-  const body = bodyTemplate({
-    redirect_uri,
-    client_id: oauth2_client_id,
-    client_secret: oauth2_client_secret,
-    config,
-    ...oauth2_injected_values,
-    ...params,
-  });
+  let body = null;
+  if (oauth2_spec.accessTokenBody) {
+    const bodyTemplate = Handlebars.compile(
+      oauth2_spec.accessTokenBody
+    );
+    body = bodyTemplate({
+      redirect_uri,
+      client_id: oauth2_client_id,
+      client_secret: oauth2_client_secret,
+      config,
+      ...oauth2_injected_values,
+      ...params,
+    });
+  }
 
   let headers = {};
   if (oauth2_spec.accessTokenHeaders) {


### PR DESCRIPTION
tiktok requires a POST request with no body

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/estuary/animated-carnival/73)
<!-- Reviewable:end -->
